### PR TITLE
Allow charset in multipart Content-Type

### DIFF
--- a/R/get_boundary.R
+++ b/R/get_boundary.R
@@ -1,6 +1,6 @@
 get_boundary <- function(content_type){
   # Check for multipart
-  if(!grepl("multipart/form-data; boundary=", content_type, fixed = TRUE))
+  if(!grepl("multipart/form-data;", content_type, fixed = TRUE) || !grepl("boundary=", content_type, fixed = TRUE))
     stop("Content type is not multipart/form-data: ", content_type)
 
   # Extract bounary

--- a/R/parse_http.R
+++ b/R/parse_http.R
@@ -25,7 +25,7 @@ parse_http <- function(body, content_type, ...){
   content_type <- sub("Content-Type: ?", "", content_type, ignore.case=TRUE);
 
   # Switch by content-type
-  if(grepl("multipart/form-data; boundary=", content_type, fixed=TRUE)){
+  if(grepl("multipart/form-data;", content_type, fixed=TRUE) && grepl("boundary=", content_type, fixed=TRUE)){
     return(parse_multipart(body, get_boundary(content_type)))
   } else if(grepl("application/x-www-form-urlencoded", content_type, fixed=TRUE)){
     return(parse_query(body))


### PR DESCRIPTION
Hello, I'm having issue with multipart requests from Java Spring which always add `charset=utf-8` between the multipart and the boundary : `Content-Type: multipart/form-data;charset=utf-8;boundary=xxxxxx;`. Haven't found easy way to change that, and seems to be a correct way to set charset according to W3C.
This is not allowed by webutils (charset can only be put after the boundary for now).
Here is a proposal to fix it.