### PR TITLE
Remove quotes from bounary if any

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: webutils
 Type: Package
 Title: Utility Functions for Developing Web Applications
-Version: 1.1
+Version: 1.2
 Author: Jeroen Ooms
 Maintainer: Jeroen Ooms <jeroen@berkeley.edu>
 Description: Parses http request data in application/json, multipart/form-data, 

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+1.2
+  - Remove quotes from bounary if any (#8)
+
 1.1
   - Allow charset in multipart Content-Type (#3)
 

--- a/R/get_boundary.R
+++ b/R/get_boundary.R
@@ -7,5 +7,6 @@ get_boundary <- function(content_type){
 
   # Extract bounary
   m <- regexpr('boundary=[^; ]{2,}', content_type, ignore.case = TRUE)
-  sub('boundary=','',regmatches(content_type, m)[[1]])
+  boundary <- sub('boundary=','',regmatches(content_type, m)[[1]])
+  sub('^"(.*)"$', "\\1", boundary)
 }


### PR DESCRIPTION
Sorry, was sleeping (#6).

I think it should go in `get_boundary` so get_boundary return a valid boundary.